### PR TITLE
Update to LTS 13.13

### DIFF
--- a/curl-runnings.cabal
+++ b/curl-runnings.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.31.1.
+-- This file has been generated from package.yaml by hpack version 0.31.2.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: e7cff7f0f8e0a24c815714efc642a28f90928aa4c4dc7cc5743c8bfb9ece772c
+-- hash: 107f33201b37a94190519b2e8eb100aa18aadf1f6567dca84d9482b4c7c68a8b
 
 name:           curl-runnings
 version:        0.10.0
@@ -43,9 +43,8 @@ library
     , hspec >=2.4.4
     , hspec-expectations >=0.8.2
     , http-client-tls >=0.3.5.3
-    , http-conduit >=2.2.4
-    , http-types >=0.9.1
-    , megaparsec >=6.3.0
+    , http-conduit >=2.3.6
+    , megaparsec >=7.0.4
     , pretty-simple >=2.0.2.1
     , regex-posix >=0.95.2
     , text >=1.2.2.2

--- a/package.yaml
+++ b/package.yaml
@@ -31,9 +31,8 @@ library:
   - directory >=1.3.0.2
   - hspec >= 2.4.4
   - hspec-expectations >=0.8.2
-  - http-conduit >=2.2.4
-  - http-types >=0.9.1
-  - megaparsec >=6.3.0
+  - http-conduit >=2.3.6
+  - megaparsec >=7.0.4
   - connection >=0.2.8
   - http-client-tls >=0.3.5.3
   - pretty-simple >=2.0.2.1

--- a/src/Testing/CurlRunnings.hs
+++ b/src/Testing/CurlRunnings.hs
@@ -27,8 +27,8 @@ import qualified Data.Yaml.Include                    as YI
 import           Network.Connection                   (TLSSettings (..))
 import           Network.HTTP.Client.TLS              (mkManagerSettings)
 import           Network.HTTP.Conduit
-import           Network.HTTP.Simple
-import qualified Network.HTTP.Types.Header            as HTTP
+import           Network.HTTP.Simple                  hiding (Header)
+import qualified Network.HTTP.Simple                  as HTTP
 import           System.Directory
 import           System.Environment
 import           Testing.CurlRunnings.Internal

--- a/src/Testing/CurlRunnings/Internal/Parser.hs
+++ b/src/Testing/CurlRunnings/Internal/Parser.hs
@@ -48,7 +48,7 @@ parseQuery q =
   let trimmed = T.strip q
   in case Text.Megaparsec.parse parseFullTextWithQuery "" trimmed of
        Right a -> Right a >>= validateQuery
-       Left a -> Left $ QueryParseError (T.pack $ parseErrorPretty a) q
+       Left a -> Left $ QueryParseError (T.pack $ errorBundlePretty a) q
 
 -- | Once we have parsed a query successfully, ensure that it is a legal query
 validateQuery :: [InterpolatedQuery] -> Either QueryError [InterpolatedQuery]
@@ -137,11 +137,11 @@ interpolatedQueryParser = do
   else return $ InterpolatedQuery (T.pack text) q
 
 leadingText :: Parser String
-leadingText = manyTill anyChar $ lookAhead (symbol "$<" <|> "${")
+leadingText = manyTill anySingle $ lookAhead (symbol "$<" <|> "${")
 
 noQueryText :: Parser InterpolatedQuery
 noQueryText = do
-  str <- some anyChar
+  str <- some anySingle
   eof
   if "$<" `isInfixOf` str
     then fail "invalid `$<` found"

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-12.14
+resolver: lts-13.13
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/stack.yaml
+++ b/stack.yaml
@@ -40,6 +40,8 @@ packages:
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
 # extra-deps: []
+extra-deps:
+  - pretty-simple-2.1.0.1
 
 # Override default flag values for local packages and extra-deps
 # flags: {}


### PR DESCRIPTION
Megaparsec 7 is a bit faster and has some error message improvements.
This isn't really justification enough, but this should enable this
package to build in nixpkgs.

The new Header type in http-conduit has also been used over the one
exported by http-types allowing the http-types dependency to be removed.