### PR TITLE
Removes extra-deps requirement

### DIFF
--- a/src/Testing/CurlRunnings/Types.hs
+++ b/src/Testing/CurlRunnings/Types.hs
@@ -361,7 +361,7 @@ instance Show CaseResult where
     T.unpack $ makeRed "[FAIL] " <>
     name c <>
     "\n" <>
-    mconcat (map ((\s -> "\nAssertion failed: " <> s) . (<> "\n") . pShow) failures)
+    mconcat (map ((\s -> "\nAssertion failed: " <> s) . (<> "\n") . (T.pack . show)) failures)
 
 -- | A wrapper type around a set of test cases. This is the top level spec type
 -- that we parse a test spec file into

--- a/stack.yaml
+++ b/stack.yaml
@@ -40,8 +40,7 @@ packages:
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
 # extra-deps: []
-extra-deps:
-  - pretty-simple-2.1.0.1
+extra-deps: []
 
 # Override default flag values for local packages and extra-deps
 # flags: {}


### PR DESCRIPTION
Realized that the reason for the extra whitespace was that some of the
results were being passed through `pShow` twice which was escaping some
characters and adding whitespace. This commit prevents that behavior by
replacing one usage of pShow with a composition of show and Text.pack
which prevents that from happening.

Open to suggestions on who to improve this as it's not a super clean solution.