### PR TITLE
Adds Parser for header fields to support header values containing colons

### DIFF
--- a/curl-runnings.cabal
+++ b/curl-runnings.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: c5eff7acb49843acbacdcf64e3e57fd05242eee41e466f2468cc9bf696b5f666
+-- hash: 51c9e5ff454be8fe0989ca3322dcbd37f212155bda9b02be4e839b047154e340
 
 name:           curl-runnings
 version:        0.11.1
@@ -36,6 +36,7 @@ library
       Testing.CurlRunnings.Types
       Testing.CurlRunnings.Internal
       Testing.CurlRunnings.Internal.Parser
+      Testing.CurlRunnings.Internal.Headers
   other-modules:
       Paths_curl_runnings
   hs-source-dirs:
@@ -94,4 +95,5 @@ test-suite curl-runnings-test
     , directory >=1.3.0.2
     , hspec >=2.4.4
     , hspec-expectations >=0.8.2
+    , text >=1.2.2.2
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -24,6 +24,7 @@ library:
   - Testing.CurlRunnings.Types
   - Testing.CurlRunnings.Internal
   - Testing.CurlRunnings.Internal.Parser
+  - Testing.CurlRunnings.Internal.Headers
   dependencies:
   - aeson >=1.2.4.0
   - bytestring >=0.10.8.2
@@ -75,3 +76,4 @@ tests:
     - directory >=1.3.0.2
     - hspec >= 2.4.4
     - hspec-expectations >=0.8.2
+    - text >=1.2.2.2

--- a/src/Testing/CurlRunnings/Internal/Headers.hs
+++ b/src/Testing/CurlRunnings/Internal/Headers.hs
@@ -1,0 +1,97 @@
+{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Module defining the Header and Headers types and a parser with a FromJSON
+-- instance for the Headers type.
+--
+-- Headers are parsed from a semi-colon separated sequence of key:value pairs.
+-- Some examples:
+--
+-- > "key: value"
+-- > "key1: value1; key2: value2"
+--
+-- Keys can be any sequence of ASCII characters excluding ':' and must not be
+-- all whitespace. For example:
+--
+-- > " : value"
+--
+-- is invalid.
+--
+-- Values can be any sequence of ASCII characters excluding ';' and may be all
+-- whitespace. For example:
+--
+-- > "key : "
+--
+-- is valid.
+module Testing.CurlRunnings.Internal.Headers
+    ( Header (..)
+    , Headers (..)
+    , parseHeaders
+    ) where
+
+import           Data.Aeson
+import           Data.Aeson.Types           hiding (Parser)
+import           Data.Bifunctor             (Bifunctor (..))
+import           Data.Char                  (isAscii, isSpace)
+import           Data.Functor               (void)
+import qualified Data.Text                  as T
+import           Data.Void
+import           GHC.Generics
+import           Text.Megaparsec
+import           Text.Megaparsec.Char
+import qualified Text.Megaparsec.Char.Lexer as L
+
+-- | A representation of a single header
+data Header =
+  Header T.Text
+         T.Text
+  deriving (Show, Generic, Eq)
+
+instance ToJSON Header
+
+instance ToJSON Headers
+
+-- | Simple container for a list of headers, useful for a vehicle for defining a
+-- fromJSON
+newtype Headers =
+  HeaderSet [Header]
+  deriving (Show, Generic, Eq)
+
+instance FromJSON Headers where
+  parseJSON a@(String v) =
+    case parseHeaders v of
+      Right h -> return h
+      Left e  -> typeMismatch ("Header failure: " ++ T.unpack e) a
+  parseJSON invalid = typeMismatch "Header" invalid
+
+-- | Given a header text, attempt to parse it into Headers.
+parseHeaders :: T.Text -> Either T.Text Headers
+parseHeaders hs = let trimmed = T.strip hs in
+  first (T.pack . errorBundlePretty) (Text.Megaparsec.parse headersParser "" trimmed)
+
+type Parser = Parsec Void T.Text
+
+headerColon :: Parser T.Text
+headerColon = L.symbol space ":"
+
+headerSemiColon :: Parser T.Text
+headerSemiColon = L.symbol space ";"
+
+endOfHeader :: Parser ()
+endOfHeader = try (void headerSemiColon) <|> eof
+
+headerParser :: Parser Header
+headerParser = do
+  key <- do
+    firstChar <- satisfy asciiExcludingColonAndSpace
+    rest <- takeWhileP (Just "header key") asciiExcludingColon <* headerColon
+    return $ T.singleton firstChar <> rest
+  value <- takeWhileP (Just "header value") asciiExcludingSemiColon <* endOfHeader
+  return $ Header (T.strip key) (T.strip value) where
+    asciiExcludingColon = asciiExcludingChar ':'
+    asciiExcludingSemiColon = asciiExcludingChar ';'
+    asciiExcludingColonAndSpace t = asciiExcludingColon t && not (isSpace t)
+    asciiExcludingChar c t =  isAscii t && t /= c
+
+headersParser :: Parser Headers
+headersParser = HeaderSet <$> some headerParser

--- a/src/Testing/CurlRunnings/Internal/Parser.hs
+++ b/src/Testing/CurlRunnings/Internal/Parser.hs
@@ -34,6 +34,8 @@ module Testing.CurlRunnings.Internal.Parser
       parseQuery
     ) where
 
+import           Data.Bifunctor             (Bifunctor (..))
+import           Data.Char                  (isAscii)
 import           Data.List
 import qualified Data.Text                  as T
 import           Data.Void
@@ -151,4 +153,3 @@ noQueryText = do
 
 parseFullTextWithQuery :: Parser [InterpolatedQuery]
 parseFullTextWithQuery = many ((try interpolatedQueryParser) <|> noQueryText)
-


### PR DESCRIPTION
I've found curl-runnings very useful in a recent project. I had to make a few modifications that I'm going to contribute back.

Firstly, I needed the specs to have support for header values that contain colons (e.g `"key: a:b:c"`). This PR adds support for this use-case by adding a Parser for Headers.