### PR TITLE
Adds support for queryParameters specified as an object

### DIFF
--- a/curl-runnings.cabal
+++ b/curl-runnings.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 51c9e5ff454be8fe0989ca3322dcbd37f212155bda9b02be4e839b047154e340
+-- hash: a946327b114d0f6d99ee35d341704a9afe9bc10e093496c4ebce60ac183c9083
 
 name:           curl-runnings
 version:        0.11.1
@@ -52,6 +52,7 @@ library
     , hspec-expectations >=0.8.2
     , http-client-tls >=0.3.5.3
     , http-conduit >=2.3.6
+    , http-types >=0.12.3
     , megaparsec >=7.0.4
     , pretty-simple >=2.0.2.1
     , regex-posix >=0.95.2

--- a/examples/example-spec.yaml
+++ b/examples/example-spec.yaml
@@ -6,6 +6,8 @@ cases:
   - name: test 1 # required
     url: http://your-endpoint.com/status # required
     requestMethod: GET # required
+    queryParameters: # optional (in addition to those set on the url).
+        key: value
     # [Optional] Specify the json payload we expect here
     # The 1 key in this block should be either:
     # exactly | contains

--- a/package.yaml
+++ b/package.yaml
@@ -36,6 +36,7 @@ library:
   - megaparsec >=7.0.4
   - connection >=0.2.8
   - http-client-tls >=0.3.5.3
+  - http-types >=0.12.3
   - pretty-simple >=2.0.2.1
   - regex-posix >=0.95.2
   - text >=1.2.2.2

--- a/src/Testing/CurlRunnings/Types.hs
+++ b/src/Testing/CurlRunnings/Types.hs
@@ -11,6 +11,8 @@ module Testing.CurlRunnings.Types
   , Header(..)
   , HeaderMatcher(..)
   , Headers(..)
+  , QueryParameter(..)
+  , QueryParameters(..)
   , HttpMethod(..)
   , JsonMatcher(..)
   , JsonSubExpr(..)

--- a/src/Testing/CurlRunnings/Types.hs
+++ b/src/Testing/CurlRunnings/Types.hs
@@ -191,14 +191,14 @@ instance FromJSON StatusCodeMatcher where
   parseJSON invalid        = typeMismatch "StatusCodeMatcher" invalid
 
 -- | A representation of a single query parameter
-data QueryParameter = QueryParameter T.Text T.Text deriving (Show, Generic)
-
-instance ToJSON QueryParameter
+data QueryParameter = QueryParameter T.Text T.Text deriving Show
 
 -- | A container for a list of query parameters
-newtype QueryParameters = QueryParameters [QueryParameter] deriving (Show, Generic)
+newtype QueryParameters = QueryParameters [QueryParameter] deriving Show
 
-instance ToJSON QueryParameters
+instance ToJSON QueryParameters where
+  toJSON (QueryParameters qs) =
+    object (fmap (\(QueryParameter k v) -> k .= toJSON v) qs)
 
 instance FromJSON QueryParameters where
   parseJSON = withObject "queryParameters" parseQueryParameters where


### PR DESCRIPTION
This PR introduces support for setting query parameters on a request in a case. Interpolation can be used in values of the key-value pairs.

The resulting request contains the query parameters from the `url` and the query parameters set in the `queryParameters` object.

For example:
```yaml
url: https://google.com?key1=value
queryParamaters:
    key2: $<RESPONSES[0].status>
```

Result in a request with URL: `https://google.com?key1=value&key2=success`  (where `success` is the result of the interpolation of the value).

I've added this because it's easier to use the interpolation in an object than in the url query string.