### PR TITLE
Use empty json request body when not specified

### DIFF
--- a/curl-runnings.cabal
+++ b/curl-runnings.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 184f34d36c0d081262571516a7ddbef911407a4dc5c3c08f6b67982a7d30d485
+-- hash: 36f3a328f46ddf05fd9e94383935542233bc1674c49698580add7c9ef9473fe0
 
 name:           curl-runnings
-version:        0.12.0
+version:        0.13.0
 synopsis:       A framework for declaratively writing curl based API tests
 description:    Please see the README on Github at <https://github.com/aviaviavi/curl-runnings#readme>
 category:       Testing

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                curl-runnings
-version:             0.12.0
+version:             0.13.0
 github:              aviaviavi/curl-runnings
 license:             MIT
 author:              Avi Press

--- a/src/Testing/CurlRunnings.hs
+++ b/src/Testing/CurlRunnings.hs
@@ -77,7 +77,12 @@ appendQueryParameters newParams r = setQueryString (existing ++ newQuery) r wher
   newQuery = NT.simpleQueryToQuery $ fmap (\(KeyValuePair k v) -> (T.encodeUtf8 k, T.encodeUtf8 v)) newParams
 
 setPayload :: Maybe Payload -> Request -> Request
-setPayload Nothing = id
+-- TODO - for backwards compatability, empty requests will set an empty json
+-- payload. Given that we support multiple content types, this funtionality
+-- isn't exactly correct anymore. This behavior should be considered
+-- deprecated and will be updated with the next major version release of
+-- curl-runnings.
+setPayload Nothing = setRequestBodyJSON emptyObject
 setPayload (Just (JSON v)) = setRequestBodyJSON v
 setPayload (Just (URLEncoded (KeyValuePairs xs))) = setRequestBodyURLEncoded $ kvpairs xs where
   kvpairs = fmap (\(KeyValuePair k v) -> (T.encodeUtf8 k, T.encodeUtf8 v))


### PR DESCRIPTION
A fully empty request body isn't valid json, which breaks backwards compatibility with the previous behaviour, which assumed all POST requests were json. This change is to fix backwards compatibility but will be reverted with a major version bump. 