### PR TITLE
Support for basic auth

### DIFF
--- a/curl-runnings.cabal
+++ b/curl-runnings.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 5a2008aba7f6690ad45088adf6e8b1be7eb49be4c65121dfd5786ffb8ad9810a
+-- hash: d5b66ab8900a29995638845bf58cc78370a00330cb11a8d2d57b631846a65e41
 
 name:           curl-runnings
 version:        0.13.0
@@ -21,6 +21,7 @@ license-file:   LICENSE
 build-type:     Simple
 extra-source-files:
     README.md
+    examples/auth.yaml
     examples/example-spec.json
     examples/example-spec.yaml
     examples/importable.yaml

--- a/curl-runnings.cabal
+++ b/curl-runnings.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 36f3a328f46ddf05fd9e94383935542233bc1674c49698580add7c9ef9473fe0
+-- hash: 5a2008aba7f6690ad45088adf6e8b1be7eb49be4c65121dfd5786ffb8ad9810a
 
 name:           curl-runnings
 version:        0.13.0
@@ -46,6 +46,7 @@ library
   build-depends:
       aeson >=1.2.4.0
     , base >=4.0 && <5
+    , base64-bytestring >=1.0.0.2
     , bytestring >=0.10.8.2
     , case-insensitive >=0.2.1
     , clock >=0.7.2

--- a/examples/auth.yaml
+++ b/examples/auth.yaml
@@ -1,0 +1,11 @@
+cases:
+  - name: Auth example
+    url: http://your-endpoint.com/status
+    requestMethod: GET
+    expectStatus: 200
+    # curl-runnings supports basic authentication at this time. if you need
+    # another auth header types, feel free to open an issue!
+    auth:
+      basic:
+        username: 'you'
+        password: 'your password'

--- a/package.yaml
+++ b/package.yaml
@@ -31,6 +31,7 @@ library:
   - aeson >=1.2.4.0
   - bytestring >=0.10.8.2
   - case-insensitive >=0.2.1
+  - base64-bytestring >=1.0.0.2
   - clock >=0.7.2
   - directory >=1.3.0.2
   - hspec >= 2.4.4

--- a/src/Testing/CurlRunnings.hs
+++ b/src/Testing/CurlRunnings.hs
@@ -117,7 +117,6 @@ runCase state@(CurlRunningsState _ _ _ tlsCheckType) curlCase = do
                 appendQueryParameters interpolatedQueryParams  .
                 (if tlsCheckType == DoTLSCheck then id else (setRequestManager manager)) $
                 initReq {method = B8S.pack . show $ requestMethod curlCase}
-          logger state DEBUG (pShow interpolatedHeaders)
           logger state DEBUG (pShow request)
           logger
             state

--- a/src/Testing/CurlRunnings.hs
+++ b/src/Testing/CurlRunnings.hs
@@ -17,6 +17,7 @@ import           Control.Exception
 import           Control.Monad
 import           Data.Aeson
 import           Data.Aeson.Types
+import qualified Data.ByteString.Base64               as B64
 import qualified Data.ByteString.Char8                as B8S
 import qualified Data.ByteString.Lazy                 as B
 import qualified Data.CaseInsensitive                 as CI
@@ -93,7 +94,7 @@ runCase :: CurlRunningsState -> CurlCase -> IO CaseResult
 runCase state@(CurlRunningsState _ _ _ tlsCheckType) curlCase = do
   let eInterpolatedUrl = interpolateQueryString state $ url curlCase
       eInterpolatedHeaders =
-        interpolateHeaders state $ fromMaybe (HeaderSet []) (headers curlCase)
+        interpolateHeaders state (auth curlCase) $ fromMaybe (HeaderSet []) (headers curlCase)
       eInterpolatedQueryParams = interpolateViaJSON state $ fromMaybe (KeyValuePairs []) (queryParameters curlCase)
   case (eInterpolatedUrl, eInterpolatedHeaders, eInterpolatedQueryParams) of
     (Left err, _, _) ->
@@ -116,6 +117,7 @@ runCase state@(CurlRunningsState _ _ _ tlsCheckType) curlCase = do
                 appendQueryParameters interpolatedQueryParams  .
                 (if tlsCheckType == DoTLSCheck then id else (setRequestManager manager)) $
                 initReq {method = B8S.pack . show $ requestMethod curlCase}
+          logger state DEBUG (pShow interpolatedHeaders)
           logger state DEBUG (pShow request)
           logger
             state
@@ -203,16 +205,26 @@ interpolatePartialHeader state (PartialHeaderMatcher k v) =
          unsafeLogger state ERROR "WARNING: empty header matcher found" . Right $
          PartialHeaderMatcher Nothing Nothing
 
-interpolateHeaders :: CurlRunningsState -> Headers -> Either QueryError Headers
-interpolateHeaders state (HeaderSet headerList) =
-  mapM
-    (\(Header k v) ->
-       case sequence
-              [interpolateQueryString state k, interpolateQueryString state v] of
-         Left err       -> Left err
-         Right [k', v'] -> Right $ Header k' v')
-    headerList >>=
-  (Right . HeaderSet)
+makeBasicAuthToken :: T.Text -> T.Text -> T.Text
+makeBasicAuthToken u p = T.decodeUtf8 . B64.encode $ T.encodeUtf8 (u <> ":" <> p)
+
+interpolateHeaders :: CurlRunningsState -> Maybe Authentication -> Headers -> Either QueryError Headers
+interpolateHeaders state maybeAuth (HeaderSet headerList) = do
+  authHeaders <- case maybeAuth of
+        (Just (BasicAuthentication u p)) ->
+          let interpolated = sequence [interpolateQueryString state u, interpolateQueryString state p] in
+          case interpolated of
+            Right [u, p] -> Right [Header "Authorization" ("Basic " <> (makeBasicAuthToken u p))]
+            Left l -> Left l
+        Nothing -> Right []
+  mainHeaders <- (mapM
+        (\(Header k v) ->
+          case sequence
+                  [interpolateQueryString state k, interpolateQueryString state v] of
+            Left err       -> Left err
+            Right [k', v'] -> Right $ Header k' v')
+      headerList)
+  Right . HeaderSet $ mainHeaders <> authHeaders
 
 -- | Does this header contain our matcher?
 headerMatches :: PartialHeaderMatcher -> Header -> Bool

--- a/src/Testing/CurlRunnings/Types.hs
+++ b/src/Testing/CurlRunnings/Types.hs
@@ -7,27 +7,28 @@
 
 module Testing.CurlRunnings.Types
   ( AssertionFailure(..)
+  , Authentication(..)
   , CaseResult(..)
-  , CurlSuite(..)
   , CurlCase(..)
+  , CurlRunningsState(..)
+  , CurlSuite(..)
+  , FullQueryText
   , Header(..)
   , HeaderMatcher(..)
   , Headers(..)
-  , KeyValuePair(..)
-  , KeyValuePairs(..)
-  , Payload(..)
   , HttpMethod(..)
+  , Index(..)
+  , InterpolatedQuery(..)
   , JsonMatcher(..)
   , JsonSubExpr(..)
+  , KeyValuePair(..)
+  , KeyValuePairs(..)
   , PartialHeaderMatcher(..)
-  , StatusCodeMatcher(..)
-  , QueryError(..)
-  , Index(..)
+  , Payload(..)
   , Query(..)
-  , InterpolatedQuery(..)
-  , FullQueryText
+  , QueryError(..)
   , SingleQueryText
-  , CurlRunningsState(..)
+  , StatusCodeMatcher(..)
   , TLSCheckType(..)
 
   , isFailing
@@ -197,6 +198,15 @@ instance FromJSON StatusCodeMatcher where
   parseJSON obj@(Array _)  = AnyCodeIn <$> parseJSON obj
   parseJSON invalid        = typeMismatch "StatusCodeMatcher" invalid
 
+data Authentication =
+  BasicAuthentication T.Text T.Text
+  deriving (Show, Generic)
+
+instance FromJSON Authentication where
+  parseJSON (Object o) = BasicAuthentication <$> (o .: "basic" >>= (.: "username")) <*> (o .: "basic" >>= (.: "password"))
+  parseJSON invalid    = typeMismatch "Authentication" invalid
+instance ToJSON Authentication
+
 -- | A single curl test case, the basic foundation of a curl-runnings test.
 data CurlCase = CurlCase
   { name            :: T.Text -- ^ The name of the test case
@@ -205,6 +215,7 @@ data CurlCase = CurlCase
   , requestData     :: Maybe Payload -- ^ Payload to send with the request, if any
   , queryParameters :: Maybe KeyValuePairs -- ^ Query parameters to set in the request, if any
   , headers         :: Maybe Headers -- ^ Headers to send with the request, if any
+  , auth            :: Maybe Authentication -- ^ Authentication to add to the request, if any
   , expectData      :: Maybe JsonMatcher -- ^ The assertions to make on the response payload, if any
   , expectStatus    :: StatusCodeMatcher -- ^ Assertion about the status code returned by the target
   , expectHeaders   :: Maybe HeaderMatcher -- ^ Assertions to make about the response headers, if any


### PR DESCRIPTION
This change lets you specify basic auth like so, per request:

```yaml
auth:
  basic:
    username: <string>
    password: <string>
```