### PR TITLE
Allow restricting number of redirects

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                curl-runnings
-version:             0.14.0
+version:             0.15.0
 github:              aviaviavi/curl-runnings
 license:             MIT
 author:              Avi Press

--- a/src/Testing/CurlRunnings.hs
+++ b/src/Testing/CurlRunnings.hs
@@ -116,7 +116,8 @@ runCase state@(CurlRunningsState _ _ _ tlsCheckType) curlCase = do
                 setRequestHeaders (toHTTPHeaders interpolatedHeaders) .
                 appendQueryParameters interpolatedQueryParams  .
                 (if tlsCheckType == DoTLSCheck then id else (setRequestManager manager)) $
-                initReq {method = B8S.pack . show $ requestMethod curlCase}
+                initReq { method = B8S.pack . show $ requestMethod curlCase
+                        , redirectCount = fromMaybe 10 (allowedRedirects curlCase) }
           logger state DEBUG (pShow request)
           logger
             state

--- a/src/Testing/CurlRunnings/Types.hs
+++ b/src/Testing/CurlRunnings/Types.hs
@@ -209,16 +209,17 @@ instance ToJSON Authentication
 
 -- | A single curl test case, the basic foundation of a curl-runnings test.
 data CurlCase = CurlCase
-  { name            :: T.Text -- ^ The name of the test case
-  , url             :: T.Text -- ^ The target url to test
-  , requestMethod   :: HttpMethod -- ^ Verb to use for the request
-  , requestData     :: Maybe Payload -- ^ Payload to send with the request, if any
-  , queryParameters :: Maybe KeyValuePairs -- ^ Query parameters to set in the request, if any
-  , headers         :: Maybe Headers -- ^ Headers to send with the request, if any
-  , auth            :: Maybe Authentication -- ^ Authentication to add to the request, if any
-  , expectData      :: Maybe JsonMatcher -- ^ The assertions to make on the response payload, if any
-  , expectStatus    :: StatusCodeMatcher -- ^ Assertion about the status code returned by the target
-  , expectHeaders   :: Maybe HeaderMatcher -- ^ Assertions to make about the response headers, if any
+  { name             :: T.Text -- ^ The name of the test case
+  , url              :: T.Text -- ^ The target url to test
+  , requestMethod    :: HttpMethod -- ^ Verb to use for the request
+  , requestData      :: Maybe Payload -- ^ Payload to send with the request, if any
+  , queryParameters  :: Maybe KeyValuePairs -- ^ Query parameters to set in the request, if any
+  , headers          :: Maybe Headers -- ^ Headers to send with the request, if any
+  , auth             :: Maybe Authentication -- ^ Authentication to add to the request, if any
+  , expectData       :: Maybe JsonMatcher -- ^ The assertions to make on the response payload, if any
+  , expectStatus     :: StatusCodeMatcher -- ^ Assertion about the status code returned by the target
+  , expectHeaders    :: Maybe HeaderMatcher -- ^ Assertions to make about the response headers, if any
+  , allowedRedirects :: Maybe Int -- ^ Number of redirects to follow. Defaults to 10
   } deriving (Show, Generic)
 
 instance FromJSON CurlCase


### PR DESCRIPTION
Adds the `allowedRedirects` option to restrict how many redirects will be performed per case.