### PR TITLE
Pin dhall imports

### DIFF
--- a/dhall/curl-runnings.dhall
+++ b/dhall/curl-runnings.dhall
@@ -1,10 +1,10 @@
-let JSON = https://prelude.dhall-lang.org/JSON/package.dhall
+let JSON = https://prelude.dhall-lang.org/v19.0.0/JSON/package.dhall
 
-let List/map = https://prelude.dhall-lang.org/List/map
+let List/map = https://prelude.dhall-lang.org/v19.0.0/List/map
 
-let Optional/map = https://prelude.dhall-lang.org/Optional/map
+let Optional/map = https://prelude.dhall-lang.org/v19.0.0/Optional/map
 
-let Map = https://prelude.dhall-lang.org/Map/Type
+let Map = https://prelude.dhall-lang.org/v19.0.0/Map/Type
 
 let HttpMethod
     : Type

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                curl-runnings
-version:             0.16.1
+version:             0.16.2
 github:              aviaviavi/curl-runnings
 license:             MIT
 author:              Avi Press


### PR DESCRIPTION
Now that we can pin dhall prelude imports, this change pins to v19.0.0. This way, we're not affected by breaking changes and can update at our discretion. 