### PR TITLE
Revert half-assed OpenSSL integration

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -28,7 +28,7 @@ library:
   - Testing.CurlRunnings.Internal.KeyValuePairs
   - Testing.CurlRunnings.Internal.Payload
   dependencies:
-  - HsOpenSSL >=0.11.7
+  - HsOpenSSL
   - aeson >=1.2.4.0
   - base64-bytestring >=1.0.0.2
   - bytestring >=0.10.8.2

--- a/package.yaml
+++ b/package.yaml
@@ -28,11 +28,10 @@ library:
   - Testing.CurlRunnings.Internal.KeyValuePairs
   - Testing.CurlRunnings.Internal.Payload
   dependencies:
-  - HsOpenSSL
   - aeson >=1.2.4.0
-  - base64-bytestring >=1.0.0.2
   - bytestring >=0.10.8.2
   - case-insensitive >=0.2.1
+  - base64-bytestring >=1.0.0.2
   - clock >=0.7.2
   - dhall >=1.8.2
   - dhall-json >= 1.0.9
@@ -40,10 +39,11 @@ library:
   - hashable >= 1.2.7.0
   - hspec >=2.4.4
   - hspec-expectations >=0.8.2
-  - http-client-openssl >=0.3.0.0
   - http-conduit >=2.3.6
-  - http-types >=0.12.3
   - megaparsec >=7.0.4
+  - connection >=0.2.8
+  - http-client-tls >=0.3.5.3
+  - http-types >=0.12.3
   - pretty-simple >=2.0.2.1
   - regex-posix >=0.95.2
   - text >=1.2.2.2

--- a/src/Testing/CurlRunnings.hs
+++ b/src/Testing/CurlRunnings.hs
@@ -45,12 +45,12 @@ import qualified Dhall.Import
 import qualified Dhall.JSON
 import qualified Dhall.Parser
 import qualified Dhall.TypeCheck
-import qualified Network.HTTP.Client.OpenSSL          as HTTP
+import           Network.Connection                   (TLSSettings (..))
+import           Network.HTTP.Client.TLS              (mkManagerSettings)
 import           Network.HTTP.Conduit
 import           Network.HTTP.Simple                  hiding (Header)
 import qualified Network.HTTP.Simple                  as HTTP
 import qualified Network.HTTP.Types                   as NT
-import           OpenSSL.Session                      (VerificationMode (..))
 import           System.Directory
 import           System.Environment
 import           Testing.CurlRunnings.Internal
@@ -95,6 +95,17 @@ resultToEither :: Result a -> Either String a
 resultToEither (Error s)   = Left s
 resultToEither (Success a) = Right a
 
+noVerifyTlsManagerSettings :: ManagerSettings
+noVerifyTlsManagerSettings = mkManagerSettings noVerifyTlsSettings Nothing
+
+noVerifyTlsSettings :: TLSSettings
+noVerifyTlsSettings =
+  TLSSettingsSimple
+  { settingDisableCertificateValidation = True
+  , settingDisableSession = True
+  , settingUseServerName = False
+  }
+
 -- | Fetch existing query parameters from the request and append those specfied in the queryParameters field.
 appendQueryParameters :: [KeyValuePair] -> Request -> Request
 appendQueryParameters newParams r = setQueryString (existing ++ newQuery) r where
@@ -133,21 +144,13 @@ runCase state@(CurlRunningsState _ _ _ tlsCheckType) curlCase = do
           return $ CaseFail curlCase Nothing Nothing [QueryFailure curlCase l] 0
         Right interpolatedData -> do
           initReq <- parseRequest $ T.unpack interpolatedUrl
-
-          manager <- newManager $ HTTP.opensslManagerSettings $ case tlsCheckType of
-            DoTLSCheck -> HTTP.defaultMakeContext HTTP.defaultOpenSSLSettings
-                -- Don't do any loading from custom locations but
-                -- instead use OpenSSL's default settings.
-                -- See https://github.com/snoyberg/http-client/issues/462
-                { HTTP.osslSettingsLoadCerts = \_ -> pure () }
-            SkipTLSCheck -> HTTP.defaultMakeContext HTTP.defaultOpenSSLSettings
-                { HTTP.osslSettingsVerifyMode = VerifyNone }
+          manager <- newManager noVerifyTlsManagerSettings
 
           let !request =
                 setPayload interpolatedData .
                 setRequestHeaders (toHTTPHeaders interpolatedHeaders) .
                 appendQueryParameters interpolatedQueryParams  .
-                setRequestManager manager $
+                (if tlsCheckType == DoTLSCheck then id else (setRequestManager manager)) $
                 initReq { method = B8S.pack . show $ requestMethod curlCase
                         , redirectCount = fromMaybe 10 (allowedRedirects curlCase) }
           logger state DEBUG (pShow request)

--- a/src/Testing/CurlRunnings.hs
+++ b/src/Testing/CurlRunnings.hs
@@ -50,7 +50,7 @@ import           Network.HTTP.Conduit
 import           Network.HTTP.Simple                  hiding (Header)
 import qualified Network.HTTP.Simple                  as HTTP
 import qualified Network.HTTP.Types                   as NT
-import           OpenSSL.Session                      (VerificationMode (..), contextSetDefaultVerifyPaths)
+import           OpenSSL.Session                      (VerificationMode (..))
 import           System.Directory
 import           System.Environment
 import           Testing.CurlRunnings.Internal
@@ -139,7 +139,7 @@ runCase state@(CurlRunningsState _ _ _ tlsCheckType) curlCase = do
                 -- Don't do any loading from custom locations but
                 -- instead use OpenSSL's default settings.
                 -- See https://github.com/snoyberg/http-client/issues/462
-                { HTTP.osslSettingsLoadCerts = contextSetDefaultVerifyPaths }
+                { HTTP.osslSettingsLoadCerts = \_ -> pure () }
             SkipTLSCheck -> HTTP.defaultMakeContext HTTP.defaultOpenSSLSettings
                 { HTTP.osslSettingsVerifyMode = VerifyNone }
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -40,8 +40,7 @@ packages:
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
 # extra-deps: []
-extra-deps:
-  - HsOpenSSL-0.11.7
+extra-deps: []
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -42,7 +42,6 @@ packages:
 # extra-deps: []
 extra-deps:
   - HsOpenSSL-0.11.7
-  - http-client-0.3.3
 
 # Override default flag values for local packages and extra-deps
 # flags: {}


### PR DESCRIPTION
This removes the hastily thrown together patches to integrate OpenSSL that I submitted a few weeks ago which should unclog CI again. 