### PR TITLE
Aeson problem

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                curl-runnings
-version:             0.16.3
+version:             0.16.4
 github:              aviaviavi/curl-runnings
 license:             MIT
 author:              Avi Press

--- a/package.yaml
+++ b/package.yaml
@@ -28,7 +28,7 @@ library:
   - Testing.CurlRunnings.Internal.KeyValuePairs
   - Testing.CurlRunnings.Internal.Payload
   dependencies:
-  - aeson >=1.2.4.0
+  - aeson >=1.2.4.0 && <2.0
   - bytestring >=0.10.8.2
   - case-insensitive >=0.2.1
   - base64-bytestring >=1.0.0.2
@@ -65,7 +65,7 @@ executables:
     - base >=4.7
     - cmdargs >=0.10.20
     - directory >=1.3.0.2
-    - aeson >=1.2.4.0
+    - aeson >=1.2.4.0 && <2.0
     - http-conduit >=2.2.4
     - bytestring >=0.10.8.2
     - curl-runnings
@@ -85,7 +85,7 @@ tests:
     - bytestring >=0.10.8.2
     - curl-runnings
     - directory >=1.3.0.2
-    - aeson >=1.2.4.0
+    - aeson >=1.2.4.0 && <2.0
     - hspec >= 2.4.4
     - hspec-expectations >=0.8.2
     - raw-strings-qq >= 1.1


### PR DESCRIPTION
Problem:

Currently installing curl-runnings via hackage results in a compilation error because Aeson 2.0 changed their API for keys/maps.

Solution:

Put an upper bounds on Aeson and bump the incremental version number of curl runnings. Publish to hackage and now everybody can install again.