### PR TITLE
Aeson 2.0

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -38,8 +38,6 @@ library:
   - dhall-json >= 1.0.9
   - directory >=1.3.0.2
   - hashable >= 1.2.7.0
-  - hspec >=2.4.4
-  - hspec-expectations >=0.8.2
   - http-conduit >=2.3.6
   - megaparsec >=7.0.4
   - connection >=0.2.8
@@ -48,7 +46,6 @@ library:
   - pretty-simple >=2.0.2.1
   - regex-posix >=0.95.2
   - text >=1.2.2.2
-  - time >=1.8.0.2
   - transformers >=0.5.2.0
   - unordered-containers >=0.2.8.0
   - vector >=0.12.0

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                curl-runnings
-version:             0.16.4
+version:             0.17.0
 github:              aviaviavi/curl-runnings
 license:             MIT
 author:              Avi Press

--- a/package.yaml
+++ b/package.yaml
@@ -23,6 +23,7 @@ library:
   - Testing.CurlRunnings
   - Testing.CurlRunnings.Types
   - Testing.CurlRunnings.Internal
+  - Testing.CurlRunnings.Internal.Aeson
   - Testing.CurlRunnings.Internal.Parser
   - Testing.CurlRunnings.Internal.Headers
   - Testing.CurlRunnings.Internal.KeyValuePairs

--- a/package.yaml
+++ b/package.yaml
@@ -28,7 +28,7 @@ library:
   - Testing.CurlRunnings.Internal.KeyValuePairs
   - Testing.CurlRunnings.Internal.Payload
   dependencies:
-  - aeson >=1.2.4.0 && <2.0
+  - aeson >=1.2.4.0
   - bytestring >=0.10.8.2
   - case-insensitive >=0.2.1
   - base64-bytestring >=1.0.0.2
@@ -65,7 +65,7 @@ executables:
     - base >=4.7
     - cmdargs >=0.10.20
     - directory >=1.3.0.2
-    - aeson >=1.2.4.0 && <2.0
+    - aeson >=1.2.4.0
     - http-conduit >=2.2.4
     - bytestring >=0.10.8.2
     - curl-runnings
@@ -85,7 +85,7 @@ tests:
     - bytestring >=0.10.8.2
     - curl-runnings
     - directory >=1.3.0.2
-    - aeson >=1.2.4.0 && <2.0
+    - aeson >=1.2.4.0
     - hspec >= 2.4.4
     - hspec-expectations >=0.8.2
     - raw-strings-qq >= 1.1

--- a/src/Testing/CurlRunnings/Internal.hs
+++ b/src/Testing/CurlRunnings/Internal.hs
@@ -20,14 +20,11 @@ module Testing.CurlRunnings.Internal
   ) where
 
 import           Control.Monad
-import           Data.Monoid
 import qualified Data.Text          as T
 import qualified Data.Text.Lazy     as TL
 import           Debug.Trace
 import           System.Clock
 import qualified Text.Pretty.Simple as P
-import           Text.Printf
-
 
 makeGreen :: T.Text -> T.Text
 makeGreen s = "\x1B[32m" <> s <> "\x1B[0m"
@@ -83,9 +80,6 @@ nowMillis :: IO Integer
 nowMillis = do
   t <- getTime Realtime
   return $ (toNanoSecs t) `div` 1000000
-
-roundToStr :: (PrintfArg a, Floating a) => a -> String
-roundToStr = printf "%0.2f"
 
 millisToS :: Integer -> Double
 millisToS t = (fromIntegral t :: Double) / 1000.0

--- a/src/Testing/CurlRunnings/Internal/Aeson.hs
+++ b/src/Testing/CurlRunnings/Internal/Aeson.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE CPP #-}
+
+-- | Module for the purpose of Aeson compatibility
+module Testing.CurlRunnings.Internal.Aeson
+  ( module Map
+  , KeyType
+  , MapType
+  , findWithDefault
+  , fromText
+  , toText
+  ) where
+
+import Data.Text (Text)
+
+#if MIN_VERSION_aeson(2,0,0)
+
+import Data.Aeson.KeyMap as Map
+import Data.Aeson.Key (Key, fromText, toText)
+
+type MapType v = Map.KeyMap v
+type KeyType = Key
+
+#else
+
+import Data.HashMap.Strict as Map
+
+type MapType v = Map.HashMap Text v
+type KeyType = Text
+
+fromText :: Text -> Text
+fromText = id
+
+toText :: Text -> Text
+toText = id
+
+#endif
+
+findWithDefault :: a -> KeyType -> MapType a -> a
+findWithDefault def k kv = case Map.lookup k kv of
+    Just v -> v
+    _      -> def
+{-# INLINABLE findWithDefault #-}

--- a/src/Testing/CurlRunnings/Internal/Aeson.hs
+++ b/src/Testing/CurlRunnings/Internal/Aeson.hs
@@ -10,7 +10,9 @@ module Testing.CurlRunnings.Internal.Aeson
   , toText
   ) where
 
+#if __GLASGOW_HASKELL__ < 810
 import Data.Text (Text)
+#endif
 
 #if MIN_VERSION_aeson(2,0,0)
 

--- a/src/Testing/CurlRunnings/Internal/KeyValuePairs.hs
+++ b/src/Testing/CurlRunnings/Internal/KeyValuePairs.hs
@@ -17,15 +17,15 @@ module Testing.CurlRunnings.Internal.KeyValuePairs
 import           Data.Aeson
 import           Data.Aeson.Types
 import qualified Data.ByteString.Lazy as LBS
-import           Data.HashMap.Strict  as H
 import qualified Data.Text            as T
 import           Data.Text.Encoding   as T
+import qualified Testing.CurlRunnings.Internal.Aeson as A
 
 -- | A container for a list of key-value pairs
 newtype KeyValuePairs = KeyValuePairs [KeyValuePair] deriving Show
 
 -- | A representation of a single key-value pair
-data KeyValuePair = KeyValuePair T.Text T.Text deriving Show
+data KeyValuePair = KeyValuePair A.KeyType T.Text deriving Show
 
 instance ToJSON KeyValuePairs where
   toJSON (KeyValuePairs qs) =
@@ -33,8 +33,8 @@ instance ToJSON KeyValuePairs where
 
 instance FromJSON KeyValuePairs where
   parseJSON = withObject "keyValuePairs" parseKeyValuePairs where
-    parseKeyValuePairs o = KeyValuePairs <$> traverse parseKeyValuePair (H.toList o)
-    parseKeyValuePair (t, v) = KeyValuePair t <$> parseSingleValueType v
+    parseKeyValuePairs o = KeyValuePairs <$> traverse parseKeyValuePair (A.toList o)
+    parseKeyValuePair (k, v) = KeyValuePair k <$> parseSingleValueType v
 
 parseSingleValueType :: Value -> Parser T.Text
 parseSingleValueType (Bool b)   = parseToText b

--- a/src/Testing/CurlRunnings/Internal/KeyValuePairs.hs
+++ b/src/Testing/CurlRunnings/Internal/KeyValuePairs.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings  #-}
+{-# LANGUAGE StandaloneDeriving #-}
 
 -- | A module defining the KeyValuePairs type. This type may be used to
 -- represent a structure in a specification that is a collection of
@@ -17,6 +18,7 @@ module Testing.CurlRunnings.Internal.KeyValuePairs
 import           Data.Aeson
 import           Data.Aeson.Types
 import qualified Data.ByteString.Lazy as LBS
+import           Data.List            ((\\))
 import qualified Data.Text            as T
 import           Data.Text.Encoding   as T
 import qualified Testing.CurlRunnings.Internal.Aeson as A
@@ -26,6 +28,12 @@ newtype KeyValuePairs = KeyValuePairs [KeyValuePair] deriving Show
 
 -- | A representation of a single key-value pair
 data KeyValuePair = KeyValuePair A.KeyType T.Text deriving Show
+
+deriving instance Eq KeyValuePair
+
+-- KeyValuePairs should be considered equal if they contain the same elements.
+instance Eq KeyValuePairs where
+  (==) (KeyValuePairs x) (KeyValuePairs y) = null (x \\ y) && null (y \\ x)
 
 instance ToJSON KeyValuePairs where
   toJSON (KeyValuePairs qs) =

--- a/src/Testing/CurlRunnings/Internal/Parser.hs
+++ b/src/Testing/CurlRunnings/Internal/Parser.hs
@@ -34,9 +34,9 @@ module Testing.CurlRunnings.Internal.Parser
       parseQuery
     ) where
 
-import           Data.Bifunctor             (Bifunctor (..))
-import           Data.Char                  (isAscii)
-import           Data.List
+import           Data.Bifunctor             ()
+import           Data.Char                  ()
+import           Data.List                  (isInfixOf)
 import qualified Data.Text                  as T
 import           Data.Void
 import           Testing.CurlRunnings.Types

--- a/src/Testing/CurlRunnings/Internal/Payload.hs
+++ b/src/Testing/CurlRunnings/Internal/Payload.hs
@@ -53,28 +53,28 @@ module Testing.CurlRunnings.Internal.Payload
 
 import           Data.Aeson
 import qualified Data.Char                                   as C
-import qualified Data.HashMap.Strict                         as H
 import qualified Data.Text                                   as T
 import           GHC.Generics
+import qualified Testing.CurlRunnings.Internal.Aeson         as A
 import           Testing.CurlRunnings.Internal.KeyValuePairs
 
 data Payload = JSON Value | URLEncoded KeyValuePairs deriving Generic
 
 instance Show Payload where
   show (JSON v) = show v
-  show (URLEncoded (KeyValuePairs xs)) = T.unpack $ T.intercalate "&" $ fmap (\(KeyValuePair k v) -> k <> "=" <> v) xs
+  show (URLEncoded (KeyValuePairs xs)) = T.unpack $ T.intercalate "&" $ fmap (\(KeyValuePair k v) -> A.toText k <> "=" <> v) xs
 
-payloadTagFieldName :: T.Text
+payloadTagFieldName :: A.KeyType
 payloadTagFieldName = "bodyType"
 
-payloadContentsFieldName :: T.Text
+payloadContentsFieldName :: A.KeyType
 payloadContentsFieldName = "content"
 
 instance FromJSON Payload where
   parseJSON v = withObject "payload" parsePayload v where
-    parsePayload o = if not (H.member payloadTagFieldName o) then return (JSON v) else genericParseJSON payloadOptions v
-    payloadOptions = defaultOptions { sumEncoding = TaggedObject { tagFieldName = T.unpack payloadTagFieldName
-                                                                 , contentsFieldName = T.unpack payloadContentsFieldName
+    parsePayload o = if not (A.member payloadTagFieldName o) then return (JSON v) else genericParseJSON payloadOptions v
+    payloadOptions = defaultOptions { sumEncoding = TaggedObject { tagFieldName = T.unpack . A.toText $ payloadTagFieldName
+                                                                 , contentsFieldName = T.unpack . A.toText $ payloadContentsFieldName
                                                                  }
                                     , constructorTagModifier = fmap C.toLower
                                     }

--- a/src/Testing/CurlRunnings/Types.hs
+++ b/src/Testing/CurlRunnings/Types.hs
@@ -49,6 +49,7 @@ import qualified Data.Text                                   as T
 import qualified Data.Vector                                 as V
 import           GHC.Generics
 import           Testing.CurlRunnings.Internal
+import qualified Testing.CurlRunnings.Internal.Aeson         as A
 import           Testing.CurlRunnings.Internal.Headers
 import           Testing.CurlRunnings.Internal.KeyValuePairs
 import           Testing.CurlRunnings.Internal.Payload
@@ -92,9 +93,9 @@ instance FromJSON JsonMatcher where
     | justAndNotEmpty "notContains" v = NotContains <$> v .: "notContains"
   parseJSON invalid = typeMismatch "JsonMatcher" invalid
 
-justAndNotEmpty :: (Eq k, Hashable k) => k -> H.HashMap k Value -> Bool
+justAndNotEmpty :: A.KeyType -> A.MapType Value -> Bool
 justAndNotEmpty key obj =
-  (isJust $ H.lookup key obj) && (H.lookup key obj /= Just Null)
+  isJust (A.lookup key obj) && A.lookup key obj /= Just Null
 
 -- | Simple predicate to check value constructor type
 isContains :: JsonMatcher -> Bool
@@ -177,12 +178,12 @@ data JsonSubExpr
 instance FromJSON JsonSubExpr where
   parseJSON (Object v)
     | justAndNotEmpty "keyValueMatch" v =
-      let toParse = fromJust $ H.lookup "keyValueMatch" v
+      let toParse = fromJust $ A.lookup "keyValueMatch" v
       in case toParse of
            Object o -> KeyValueMatch <$> o .: "key" <*> o .: "value"
            _        -> typeMismatch "JsonSubExpr" toParse
     | justAndNotEmpty "keyMatch" v =
-      let toParse = fromJust $ H.lookup "keyMatch" v
+      let toParse = fromJust $ A.lookup "keyMatch" v
       in case toParse of
            String s -> return $ KeyMatch s
            _        -> typeMismatch "JsonSubExpr" toParse
@@ -403,7 +404,7 @@ isFailing :: CaseResult -> Bool
 isFailing = not . isPassing
 
 -- | A map of the system environment
-type Environment = H.HashMap T.Text T.Text
+type Environment = A.MapType T.Text
 
 data TLSCheckType = SkipTLSCheck | DoTLSCheck deriving (Show, Eq)
 

--- a/src/Testing/CurlRunnings/Types.hs
+++ b/src/Testing/CurlRunnings/Types.hs
@@ -40,11 +40,7 @@ module Testing.CurlRunnings.Types
 
 import           Data.Aeson
 import           Data.Aeson.Types
-import qualified Data.Char                                   as C
-import           Data.Hashable                               (Hashable)
-import qualified Data.HashMap.Strict                         as H
 import           Data.Maybe
-import           Data.Monoid
 import qualified Data.Text                                   as T
 import qualified Data.Vector                                 as V
 import           GHC.Generics
@@ -429,11 +425,6 @@ data Index
   | ArrayIndex Integer
   deriving (Show)
 
-printOriginalQuery :: Index -> String
-printOriginalQuery (CaseResultIndex t) = "RESPONSES[" ++ show t ++ "]"
-printOriginalQuery (KeyIndex key)      = "." ++ T.unpack key
-printOriginalQuery (ArrayIndex i)      = printf "[%d]" i
-
 -- | A single entity to be queries from a json value
 data Query =
   -- | A single query contains a list of discrete index operations
@@ -452,12 +443,6 @@ data InterpolatedQuery
   -- | Just a query, no leading text
   | NonInterpolatedQuery Query
   deriving (Show)
-
-printQueryString :: InterpolatedQuery -> String
-printQueryString (LiteralText t) = show t
-printQueryString (InterpolatedQuery raw (Query indexes)) =
-  printf "%s$<%s>" raw $ concatMap show indexes
-printQueryString (NonInterpolatedQuery (Query indexes)) = printf "$<%s>" (concatMap show indexes)
 
 -- | The full string in which a query appears, eg "prefix-${{RESPONSES[0].key.another_key[0].last_key}}"
 type FullQueryText = T.Text

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -13,6 +13,7 @@ import           System.Directory
 import           Test.Hspec
 import           Testing.CurlRunnings
 import           Testing.CurlRunnings.Internal
+import qualified Testing.CurlRunnings.Internal.Aeson         as A
 import           Testing.CurlRunnings.Internal.Headers
 import           Testing.CurlRunnings.Internal.KeyValuePairs
 import           Testing.CurlRunnings.Internal.Parser
@@ -156,7 +157,7 @@ shouldBeHeaders actual expected =
   let expectedHeaders = Right . HeaderSet $ uncurry Header <$> expected in
     actual `shouldBe` expectedHeaders
 
-shouldBeKeyValuePairs :: ByteString -> [(T.Text, T.Text)] -> Expectation
+shouldBeKeyValuePairs :: ByteString -> [(A.KeyType, T.Text)] -> Expectation
 shouldBeKeyValuePairs json expected = actual `shouldBe` expectedKeyValuePairs where
   actual = eitherDecodeStrict json
   expectedKeyValuePairs = Right . KeyValuePairs $ uncurry KeyValuePair <$> expected

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,13 +1,11 @@
 {-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE QuasiQuotes        #-}
-{-# LANGUAGE StandaloneDeriving #-}
 
 module Main where
 
 import           Data.Aeson
 import           Data.ByteString                             (ByteString)
 import           Data.Either
-import           Data.List
 import qualified Data.Text                                   as T
 import           System.Directory
 import           Test.Hspec
@@ -93,12 +91,12 @@ main = hspec $
   it "arrayGet should handle positive and negative indexes correctly" $ do
     let a = [1, 2, 3]
         b = [] :: [Int]
-    (arrayGet a 0) `shouldBe` Just 1
-    (arrayGet a 1) `shouldBe` Just 2
-    (arrayGet a 2) `shouldBe` Just 3
-    (arrayGet a (-1)) `shouldBe` Just 3
-    (arrayGet a (-2)) `shouldBe` Just 2
-    (arrayGet a (-3)) `shouldBe` Just 1
+    (arrayGet a 0) `shouldBe` Just (1 :: Integer)
+    (arrayGet a 1) `shouldBe` Just (2 :: Integer)
+    (arrayGet a 2) `shouldBe` Just (3 :: Integer)
+    (arrayGet a (-1)) `shouldBe` Just (3 :: Integer)
+    (arrayGet a (-2)) `shouldBe` Just (2 :: Integer)
+    (arrayGet a (-3)) `shouldBe` Just (1 :: Integer)
     (arrayGet a (-4)) `shouldBe` Nothing
     (arrayGet a 3) `shouldBe` Nothing
     (arrayGet b 0) `shouldBe` Nothing
@@ -158,15 +156,9 @@ shouldBeHeaders actual expected =
     actual `shouldBe` expectedHeaders
 
 shouldBeKeyValuePairs :: ByteString -> [(A.KeyType, T.Text)] -> Expectation
-shouldBeKeyValuePairs json expected = actual `shouldBe` expectedKeyValuePairs where
-  actual = eitherDecodeStrict json
+shouldBeKeyValuePairs j expected = actual `shouldBe` expectedKeyValuePairs where
+  actual = eitherDecodeStrict j
   expectedKeyValuePairs = Right . KeyValuePairs $ uncurry KeyValuePair <$> expected
-
-deriving instance Eq KeyValuePair
-
--- KeyValuePairs should be considered equal if they contain the same elements.
-instance Eq KeyValuePairs where
-  (==) (KeyValuePairs x) (KeyValuePairs y) = null (x \\ y) && null (y \\ x)
 
 isURLEncoded :: Either String Payload -> Bool
 isURLEncoded (Right (URLEncoded _)) = True


### PR DESCRIPTION
Problem:

Currently installing curl-runnings via hackage results in a compilation error because Aeson 2.0 changed their API for keys/maps.

Solution:

Put an upper bounds on Aeson and bump the incremental version number of curl runnings. Publish to hackage and now everybody can install again.

2nd Step: add a compatibility module that can morph on the fly to Aeson 1.x and 2.x. Bump the version and publish to hackage. Now everybody can install again no matter what version of Aeson they have locally. 