### PR TITLE
Stack LTS upgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
     - uses: cachix/cachix-action@v10
       with:
-        name: scarf
+        name: aviaviavi
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
         extraPullNames: cachix,iohk,nix-community
     - run: nix build

--- a/src/Testing/CurlRunnings/Internal/Aeson.hs
+++ b/src/Testing/CurlRunnings/Internal/Aeson.hs
@@ -10,10 +10,6 @@ module Testing.CurlRunnings.Internal.Aeson
   , toText
   ) where
 
-#if __GLASGOW_HASKELL__ < 810
-import Data.Text (Text)
-#endif
-
 #if MIN_VERSION_aeson(2,0,0)
 
 import Data.Aeson.KeyMap as Map
@@ -24,7 +20,8 @@ type KeyType = Key
 
 #else
 
-import Data.HashMap.Strict as Map
+import Data.Text (Text)
+import Data.HashMap.Strict as Map hiding (findWithDefault)
 
 type MapType v = Map.HashMap Text v
 type KeyType = Text

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-16.16
+resolver: lts-18.23
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
Upgrade Stack build to LTS-18.23 which was a week ago on GHC 8.10.7. Stack is still aeson-1.x AFAIK. Cabal build with aeson-2.0 works fine too still.